### PR TITLE
:fire: leftover to supress deprecated warning in dev mode.

### DIFF
--- a/lib/remember-file-positions.coffee
+++ b/lib/remember-file-positions.coffee
@@ -1,4 +1,4 @@
-{CompositeDisposable, TextEditor} = require 'atom'
+{CompositeDisposable} = require 'atom'
 
 module.exports = RememberFilePositions =
   subscriptions: null


### PR DESCRIPTION
TextEditor constructor function seems will be deprecate in near future.
You can see you run in dev mode with `-d`.
And this package just requiring it but not used. Safely can :fire: it!
