### PR TITLE
Fix for text is not rendered correctly when onDidAttache is called twice

### DIFF
--- a/lib/remember-file-positions.coffee
+++ b/lib/remember-file-positions.coffee
@@ -11,7 +11,6 @@ module.exports = RememberFilePositions =
     @subscriptions = new CompositeDisposable
     @fileNumbers = state.fileNumbersState ? {}
     @filePositions = state.filePositionsState ? {}
-    @attachedElements = []
 
     @subscriptions.add atom.workspace.observeTextEditors (editor) =>
       editorElement = getView(editor)

--- a/lib/remember-file-positions.coffee
+++ b/lib/remember-file-positions.coffee
@@ -1,7 +1,5 @@
 {CompositeDisposable} = require 'atom'
 
-getView = atom.views.getView.bind(atom.views)
-
 module.exports = RememberFilePositions =
   subscriptions: null
   fileNumbers: {}
@@ -13,7 +11,7 @@ module.exports = RememberFilePositions =
     @filePositions = state.filePositionsState ? {}
 
     @subscriptions.add atom.workspace.observeTextEditors (editor) =>
-      editorElement = getView(editor)
+      editorElement = atom.views.getView(editor)
       uri = editor.getURI()
       {row} = editor.getCursorBufferPosition()
       if @fileNumbers[uri]? and (row in [0, @fileNumbers[uri].row])
@@ -23,7 +21,7 @@ module.exports = RememberFilePositions =
 
         # We need to know when the editor is actually attached in order to scroll.
         # Otherwise the `lineHeight` of the editor view is 0, and scrolling is impossible.
-        disposable = getView(editor).onDidAttach =>
+        disposable = editorElement.onDidAttach =>
           disposable.dispose()
           @restorePosition(editor)
 
@@ -43,7 +41,7 @@ module.exports = RememberFilePositions =
       editor.setCursorBufferPosition(cursorPosition)
 
     if (scrollState = @filePositions[uri])?
-      editorElement = getView(editor)
+      editorElement = atom.views.getView(editor)
       editorElement.setScrollTop(scrollState.top)
       editorElement.setScrollLeft(scrollState.left)
 

--- a/lib/remember-file-positions.coffee
+++ b/lib/remember-file-positions.coffee
@@ -1,5 +1,7 @@
 {CompositeDisposable} = require 'atom'
 
+getView = atom.views.getView.bind(atom.views)
+
 module.exports = RememberFilePositions =
   subscriptions: null
   fileNumbers: {}
@@ -9,45 +11,42 @@ module.exports = RememberFilePositions =
     @subscriptions = new CompositeDisposable
     @fileNumbers = state.fileNumbersState ? {}
     @filePositions = state.filePositionsState ? {}
+    @attachedElements = []
 
     @subscriptions.add atom.workspace.observeTextEditors (editor) =>
-      @handleAddTextEditor(editor)
-      @subscriptions.add atom.views.getView(editor).onDidChangeScrollTop (scroll) =>
-        @handleChangeScroll(scroll, editor)
-      @subscriptions.add editor.onDidChangeCursorPosition (event) =>
-        @handleChangeCursorPosition(event)
+      editorElement = getView(editor)
+      uri = editor.getURI()
+      {row} = editor.getCursorBufferPosition()
+      if @fileNumbers[uri]? and (row in [0, @fileNumbers[uri].row])
+        # HACK Atom to scroll to the cursor position of any TextEditors when this package is activated.
+        # This is only necessary because Atom incorrectly applies deserialized scroll values.
+        @restorePosition(editor)
 
-  handleAddTextEditor: (editor) ->
+        # We need to know when the editor is actually attached in order to scroll.
+        # Otherwise the `lineHeight` of the editor view is 0, and scrolling is impossible.
+        disposable = getView(editor).onDidAttach =>
+          disposable.dispose()
+          @restorePosition(editor)
+
+      # Preserve scroll position
+      @subscriptions.add editorElement.onDidChangeScrollTop =>
+        @filePositions[editor.getURI()] =
+          top: editorElement.getScrollTop()
+          left: editorElement.getScrollLeft()
+
+      # Preserve cursor position
+      @subscriptions.add editor.onDidChangeCursorPosition ({newBufferPosition}) =>
+        @fileNumbers[editor.getURI()] = newBufferPosition
+
+  restorePosition: (editor) ->
     uri = editor.getURI()
-    currentPosition = editor.getCursorBufferPosition()
+    if (cursorPosition = @fileNumbers[uri])?
+      editor.setCursorBufferPosition(cursorPosition)
 
-    if @fileNumbers[uri]? and (currentPosition.row is 0 or currentPosition.row is @fileNumbers[uri].row)
-      # HACK Atom to scroll to the cursor position of any TextEditors when this package is activated.
-      # This is only necessary because Atom incorrectly applies deserialized scroll values.
-      @setCursorAndScroll(editor, uri)
-
-      # We need to know when the editor is actually attached in order to scroll.
-      # Otherwise the `lineHeight` of the editor view is 0, and scrolling is impossible.
-      view = atom.views.getView(editor)
-      @subscriptions.add view.onDidAttach =>
-        @setCursorAndScroll(editor, uri)
-
-  setCursorAndScroll: (editor, uri) ->
-    position = @filePositions[uri]
-    view = atom.views.getView(editor)
-    editor.setCursorBufferPosition(@fileNumbers[uri])
-    if position?
-      view.setScrollTop(position.top)
-      view.setScrollLeft(position.left)
-
-  handleChangeCursorPosition: (event) ->
-    @fileNumbers[event.cursor.editor.getURI()] = event.newBufferPosition
-
-  handleChangeScroll: (scroll, editor) ->
-    # editor.displayBuffer.pixelPositionForScreenPosition(position)
-    view = atom.views.getView(editor)
-    screenPosition = {top: view.getScrollTop(), left: view.getScrollLeft()}
-    @filePositions[editor.getURI()] = screenPosition
+    if (scrollState = @filePositions[uri])?
+      editorElement = getView(editor)
+      editorElement.setScrollTop(scrollState.top)
+      editorElement.setScrollLeft(scrollState.left)
 
   deactivate: ->
     @subscriptions.dispose()


### PR DESCRIPTION
By uncertain reason onDidAttache is called twice( I checked by adding debugging codes ).
In that case, text of editor is not correctly rendered  and need to re-open after close

![editor-become-blank](https://cloud.githubusercontent.com/assets/155205/13154594/b7ba7464-d647-11e5-90ad-dd65fb07f503.gif)
- To reproduce:

file1 and file2 need enough amount of lines to scrollable.
1.  open file1, file2 (tab1: file1, tab2: file2 and active).
2. split-right(`cmd-k`, `right`), then close (`cmd-w`). now same state as 1.
3. close file2 by `cmd-w`.
4. split-right(`cmd-k`, `right`). file1 on left pane become partially blank.

To solve above issue, onDidAttache disposable must be disposed once it called.
In the process of investigation, I added unnecessary refactoring, so sorry this include the code not necessary to solve this issue itself.
