### PR TITLE
setCursorAndScroll: Fix setScroll* by adding setTimeout

### DIFF
--- a/lib/remember-file-positions.coffee
+++ b/lib/remember-file-positions.coffee
@@ -42,8 +42,11 @@ module.exports = RememberFilePositions =
     editor.setCursorBufferPosition(@fileNumbers[uri])
     if position?
       view = atom.views.getView(editor)
-      view.setScrollTop(position.top)
-      view.setScrollLeft(position.left)
+      # Have to setImmediate else these setScroll* have no effect
+      # - TODO Figure out why...
+      setImmediate =>
+        view.setScrollTop(position.top)
+        view.setScrollLeft(position.left)
 
   handleChangeCursorPosition: (event) ->
     @fileNumbers[event.cursor.editor.getURI()] = event.newBufferPosition

--- a/lib/remember-file-positions.coffee
+++ b/lib/remember-file-positions.coffee
@@ -42,11 +42,14 @@ module.exports = RememberFilePositions =
     editor.setCursorBufferPosition(@fileNumbers[uri])
     if position?
       view = atom.views.getView(editor)
-      # Have to setImmediate else these setScroll* have no effect
+      # Have to setTimeout(..., 0) else these setScroll* have no effect
       # - TODO Figure out why...
-      setImmediate =>
-        view.setScrollTop(position.top)
-        view.setScrollLeft(position.left)
+      setTimeout(
+        =>
+          view.setScrollTop(position.top)
+          view.setScrollLeft(position.left)
+        0
+      )
 
   handleChangeCursorPosition: (event) ->
     @fileNumbers[event.cursor.editor.getURI()] = event.newBufferPosition


### PR DESCRIPTION
- Previously, when I'd reopen an editor the `setCursorBufferPosition`
  would set the cursor as well as set the scroll (because of the default
  `autoscroll:true`), but `setScrollTop`/`setScrollLeft` would have no
  effect
- This PR adds `setTimeout` which fixes `setScrollTop`/`setScrollLeft`
  to have the intended effect
- But I don't know what the root problem is, why this fixes it, or
  whether this is the most appropriate fix

Versions:
```sh
$ atom --version
v7.9.0
$ grep version packages/remember-file-positions/package.json
  "version": "0.2.3",
```